### PR TITLE
Fix fallback to GitHub releases

### DIFF
--- a/cmd/brew-changelog.rb
+++ b/cmd/brew-changelog.rb
@@ -6,7 +6,7 @@ exec_browser *ARGV.formulae.map(&-> formula {
   case
   when changelog = changelogs[formula.name]
     return changelogs[changelog] || changelog
-  when formula.downloader.url =~ %r{^https?://github.+/[^/.]+}
+  when formula.downloader.url =~ %r{^https?://github\.com(/[^/]+){2}}
     return "#{$&}/releases"
   else formula.homepage
   end


### PR DESCRIPTION
Requires github.com, and allows for extra path segments at the end. See
for example, [the formula][1] for `lastpass-cli`.

I'm not a Ruby guy, so there may be mistakes here.

[1]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/lastpass-cli.rb